### PR TITLE
Refactor to use a Scene named PlayScene

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ yarn add phaser
 
 To use Phaser in the development setup, follow these steps:
 
-1. Import Phaser in your `src/main.ts` file:
+1. Import the `PlayScene` class in your `src/main.ts` file:
    ```typescript
-   import Phaser from 'phaser';
+   import PlayScene from './PlayScene';
    ```
 
 2. Initialize a Phaser game in your `src/main.ts` file:
@@ -48,24 +48,8 @@ To use Phaser in the development setup, follow these steps:
      type: Phaser.AUTO,
      width: 800,
      height: 600,
-     scene: {
-       preload: preload,
-       create: create,
-       update: update
-     }
+     scene: PlayScene
    };
 
    const game = new Phaser.Game(config);
-
-   function preload() {
-     // Load assets here
-   }
-
-   function create() {
-     // Create game objects here
-   }
-
-   function update() {
-     // Update game objects here
-   }
    ```

--- a/src/PlayScene.ts
+++ b/src/PlayScene.ts
@@ -1,0 +1,22 @@
+import * as Phaser from "phaser";
+import TextureGenerator from "./TextureGenerator";
+
+class PlayScene extends Phaser.Scene {
+  constructor() {
+    super({ key: 'PlayScene' });
+  }
+
+  preload() {
+    TextureGenerator.generateSolidTexture(this, 'redTexture', 100, 100, 0xff0000);
+  }
+
+  create() {
+    this.add.image(400, 300, 'redTexture');
+  }
+
+  update() {
+    // Update game objects here
+  }
+}
+
+export default PlayScene;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,28 +1,13 @@
 import * as Phaser from "phaser";
 import TextureGenerator from "./TextureGenerator";
+import PlayScene from "./PlayScene";
 
 const config = {
 	type: Phaser.AUTO,
 	width: 800,
 	height: 600,
 	parent: 'app',
-	scene: {
-		preload: preload,
-		create: create,
-		update: update,
-	},
+	scene: PlayScene,
 };
 
 const game = new Phaser.Game(config);
-
-function preload() {
-	TextureGenerator.generateSolidTexture(this, 'redTexture', 100, 100, 0xff0000);
-}
-
-function create() {
-	this.add.image(400, 300, 'redTexture');
-}
-
-function update() {
-	// Update game objects here
-}


### PR DESCRIPTION
Fixes #9

Refactor to encapsulate game functionality into a Phaser Scene named PlayScene.

* Add `src/PlayScene.ts` to define the `PlayScene` class with `preload`, `create`, and `update` methods.
* Modify `src/main.ts` to import the `PlayScene` class and update the `scene` configuration to reference `PlayScene`.
* Remove the `preload`, `create`, and `update` functions from `src/main.ts`.
* Update `README.md` to reflect the new `PlayScene` class usage.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl6/issues/9?shareId=11266c93-016e-41f6-8e61-523d7008c327).