### PR TITLE
Fix error: this.tilemap.createBlankDynamicLayer is not a function

### DIFF
--- a/src/MapGenerator.ts
+++ b/src/MapGenerator.ts
@@ -21,7 +21,7 @@ class MapGenerator {
 
     this.tilemap = this.scene.make.tilemap({ width: this.mapWidth, height: this.mapHeight, tileWidth: this.tileSize, tileHeight: this.tileSize });
     this.tileset = this.tilemap.addTilesetImage('tiles');
-    this.layer = this.tilemap.createBlankDynamicLayer('layer', this.tileset);
+    this.layer = this.tilemap.createDynamicLayer('layer', this.tileset);
   }
 
   generateMap() {


### PR DESCRIPTION
Fixes #13

Fix the runtime error by replacing the incorrect function call.

* Replace `this.tilemap.createBlankDynamicLayer` with `this.tilemap.createDynamicLayer` in `src/MapGenerator.ts` line 24 to match the correct function in Phaser version 3.55.2.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl6/issues/13?shareId=54227fdb-17de-46fb-a7af-dd5764250b76).