### PR TITLE
Fix MapGenerator.ts error on line 24

### DIFF
--- a/src/MapGenerator.ts
+++ b/src/MapGenerator.ts
@@ -10,7 +10,7 @@ class MapGenerator {
   private noiseThreshold: number;
   private tilemap: Phaser.Tilemaps.Tilemap;
   private tileset: Phaser.Tilemaps.Tileset;
-  private layer: Phaser.Tilemaps.DynamicTilemapLayer;
+  private layer: Phaser.Tilemaps.TilemapLayer;
 
   constructor(scene: Phaser.Scene, tileSize: number, mapWidth: number, mapHeight: number, noiseThreshold: number) {
     this.scene = scene;
@@ -21,7 +21,7 @@ class MapGenerator {
 
     this.tilemap = this.scene.make.tilemap({ width: this.mapWidth, height: this.mapHeight, tileWidth: this.tileSize, tileHeight: this.tileSize });
     this.tileset = this.tilemap.addTilesetImage('tiles');
-    this.layer = this.tilemap.createDynamicLayer('layer', this.tileset);
+    this.layer = this.tilemap.createLayer('layer', this.tileset);
   }
 
   generateMap() {


### PR DESCRIPTION
Fixes #15

Fix the error by replacing `createDynamicLayer` with `createLayer` in `src/MapGenerator.ts`.

* Replace `createDynamicLayer` with `createLayer` in the constructor.
* Update the type of `layer` to `Phaser.Tilemaps.TilemapLayer`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl6/issues/15?shareId=f0f9e884-952e-411a-b4b9-2503e245ee0e).